### PR TITLE
Make Select reset slice length

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -878,9 +878,10 @@ func structOnlyError(t reflect.Type) error {
 }
 
 // scanAll scans all rows into a destination, which must be a slice of any
-// type.  If the destination slice type is a Struct, then StructScan will be
-// used on each row.  If the destination is some other kind of base type, then
-// each row must only have one column which can scan into that type.  This
+// type.  It resets the slice length to zero before appending each element to
+// the slice.  If the destination slice type is a Struct, then StructScan will
+// be used on each row.  If the destination is some other kind of base type,
+// then each row must only have one column which can scan into that type.  This
 // allows you to do something like:
 //
 //    rows, _ := db.Query("select id from people;")
@@ -910,6 +911,7 @@ func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
 	if err != nil {
 		return err
 	}
+	direct.SetLen(0)
 
 	isPtr := slice.Elem().Kind() == reflect.Ptr
 	base := reflectx.Deref(slice.Elem())

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1892,3 +1892,35 @@ func TestIn130Regression(t *testing.T) {
 		}
 	})
 }
+
+func TestSelectReset(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		filledDest := []string{"a", "b", "c"}
+		err := db.Select(&filledDest, "SELECT first_name FROM person ORDER BY first_name ASC;")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(filledDest) != 2 {
+			t.Errorf("Expected 2 first names, got %d.", len(filledDest))
+		}
+		expected := []string{"Jason", "John"}
+		for i, got := range filledDest {
+			if got != expected[i] {
+				t.Errorf("Expected %d result to be %s, but got %s.", i, expected[i], got)
+			}
+		}
+
+		var emptyDest []string
+		err = db.Select(&emptyDest, "SELECT first_name FROM person WHERE first_name = 'Jack';")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify that selecting 0 rows into a nil target didn't create a
+		// non-nil slice.
+		if emptyDest != nil {
+			t.Error("Expected emptyDest to be nil")
+		}
+	})
+}


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/178404306.

This fixes issue https://github.com/jmoiron/sqlx/issues/744 by changing sqlx's Select function to reset slices before appending to them. 